### PR TITLE
Use an archive's path as the starting point of file.history for files unzipped from it

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -22,7 +22,7 @@ function mtimeFromEntry(entry) {
 	return yauzl.dosDateTimeToDate(entry.lastModFileDate, entry.lastModFileTime);
 }
 
-function toStream(zip) {
+function toStream(zip, zipPath) {
 	var result = through();
 	var q = queue();
 	var didErr = false;
@@ -46,7 +46,8 @@ function toStream(zip) {
 
 		var file = {
 			path: entry.fileName,
-			stat: stat
+			stat: stat,
+			history: [zipPath]
 		};
 
 		if (stat.isFile()) {
@@ -110,7 +111,7 @@ function unzipFile(zipPath) {
 	var result = through();
 	yauzl.open(zipPath, function (err, zip) {
 		if (err) { return result.emit('error', err); }
-		toStream(zip).pipe(result);
+		toStream(zip, zipPath).pipe(result);
 	});
 	return result;
 }
@@ -120,7 +121,7 @@ function unzip() {
 		if (!file.isBuffer()) return next(new Error('Only supports buffers'));
 		yauzl.fromBuffer(file.contents, (err, zip) => {
 			if (err) return this.emit('error', err);
-			toStream(zip)
+			toStream(zip, file.path)
 				.on('error', next)
 				.on('data', (data) => this.push(data))
 				.on('end', next);

--- a/test/tests.js
+++ b/test/tests.js
@@ -68,6 +68,21 @@ describe('gulp-vinyl-zip', function () {
 			});
 	});
 
+	it('src should begin file.history on an unzipped file with the archive\'s path', function (cb) {
+		var dest = temp.mkdirSync('gulp-vinyl-zip-test');
+
+		vfs.src(path.join(__dirname, 'assets', '*.zip'), { encoding: false })
+			.pipe(through.obj((file, enc, next) => {
+				assert(file.history[0].endsWith('archive.zip'));
+				next(null, file);
+			}))
+			.pipe(vfs.dest(dest))
+			.on('end', function () {
+				// assert(fs.existsSync(dest));
+				cb();
+			});
+	});
+
 	it('dest should be able to create an archive from another archive', function (cb) {
 		var dest = temp.openSync('gulp-vinyl-zip-test').path;
 


### PR DESCRIPTION
Vinyl files have a `history` property that automatically tracks renames and path changes as a file moves through a gulp pipeline.  Right now, unzipped files' history appears to show them just blinking into existence with no path information or clues as to where they came from. 

This will change that by simply using the source archive's current full path as the first `history` entry of each file unzipped from it. This allows tracing the origins of each file, which may be pivotal in more complex scenarios.